### PR TITLE
Bump ouroboros and more cleanup

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -52,8 +52,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: e0ccbb73296027a5e5fd224a78374321974758ce
-  --sha256: 1a6djwb2jkhh4pq6iwr10zxgpiz3n3f2yw54ciwnwqdm59cami38
+  tag: e8875cf2c7052b94f5a14afdb4315c47d10b09f0
+  --sha256: 0hl4av1xnrv2knwk739y117vcx8q8dz75bkq0mry841wmby1i9f6
   subdir:
     io-sim
     io-classes
@@ -62,4 +62,5 @@ source-repository-package
     ouroboros-network-framework
     ouroboros-network-testing
     typed-protocols
+    typed-protocols-cborg
     typed-protocols-examples

--- a/demo/acceptor.hs
+++ b/demo/acceptor.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE LambdaCase #-}
 
+import           Control.Concurrent.STM.TVar (newTVarIO)
 import           Control.Tracer (contramap, stdoutTracer)
-import           Data.IORef (newIORef)
 import           Data.Fixed (Pico)
 import           Data.Text (pack)
 import           Data.Time.Clock (secondsToNominalDiffTime)
@@ -21,16 +21,14 @@ main = do
     [path, freq]       -> return (LocalPipe path, freq)
     [host, port, freq] -> return (RemoteSocket (pack host) (read port :: Port), freq)
     _                  -> die "Usage: demo-acceptor (pathToLocalPipe | host port) freqInSecs"
-  weAreDone <- newIORef False
+  weAreDone <- newTVarIO False
   let config =
         AcceptorConfiguration
           { acceptorTracer    = contramap show stdoutTracer
           , forwarderEndpoint = listenIt
           , requestFrequency  = secondsToNominalDiffTime (read freq :: Pico)
           , whatToRequest     = GetAllMetrics
-          , actionOnResponse  = print
           , shouldWeStop      = weAreDone
-          , actionOnDone      = putStrLn "We are done!"
           }
 
   -- Create an empty EKG store.

--- a/ekg-forward.cabal
+++ b/ekg-forward.cabal
@@ -70,6 +70,7 @@ library
                        , text
                        , time
                        , typed-protocols
+                       , typed-protocols-cborg
                        , unordered-containers
 
 executable demo-forwarder
@@ -95,6 +96,7 @@ executable demo-acceptor
                        , contra-tracer
                        , ekg-core
                        , ekg-forward
+                       , stm
                        , text
                        , time
 
@@ -117,6 +119,7 @@ test-suite ekg-forward-test
                        , ekg-core
                        , ekg-forward
                        , hspec
+                       , stm
                        , time
                        , unordered-containers
   ghc-options:         -threaded

--- a/src/System/Metrics/Configuration.hs
+++ b/src/System/Metrics/Configuration.hs
@@ -36,7 +36,7 @@ data AcceptorConfiguration = AcceptorConfiguration
   , requestFrequency  :: !NominalDiffTime
     -- | Specifies what to request: all existing metrics or particular metrics.
   , whatToRequest     :: !Request
-    -- | 'IORef' that can be used as a brake: if an external thread will set it to
+    -- | 'TVar' that can be used as a brake: if an external thread will set it to
     -- 'True', the acceptor will send 'MsgDone' message to the forwarder and their
     -- session will be closed.
   , shouldWeStop      :: !(TVar Bool)

--- a/src/System/Metrics/Protocol/Codec.hs
+++ b/src/System/Metrics/Protocol/Codec.hs
@@ -14,9 +14,9 @@ import           Codec.CBOR.Read (DeserialiseFailure)
 import           Control.Monad.Class.MonadST (MonadST)
 import qualified Data.ByteString.Lazy as LBS
 import           Text.Printf (printf)
-import           Ouroboros.Network.Codec (Codec, PeerHasAgency (..),
-                                          PeerRole (..), SomeMessage (..),
-                                          mkCodecCborLazyBS)
+import           Network.TypedProtocol.Codec.CBOR (Codec, PeerHasAgency (..),
+                                                   PeerRole (..), SomeMessage (..),
+                                                   mkCodecCborLazyBS)
 
 import           System.Metrics.Protocol.Type
 

--- a/test/Test/GetAllMetrics.hs
+++ b/test/Test/GetAllMetrics.hs
@@ -6,7 +6,8 @@ module Test.GetAllMetrics
 import Test.Hspec
 
 import           Control.Concurrent (forkIO, threadDelay)
-import           Data.IORef (atomicModifyIORef', newIORef)
+import           Control.Concurrent.STM (atomically)
+import           Control.Concurrent.STM.TVar (modifyTVar', newTVarIO)
 import qualified System.Metrics as EKG
 import qualified System.Metrics.Gauge as G
 import qualified System.Metrics.Label as L
@@ -27,7 +28,7 @@ getAllMetrics :: HowToConnect -> IO ()
 getAllMetrics endpoint = do
   forwarderStore <- EKG.newStore
   acceptorStore  <- EKG.newStore
-  weAreDone <- newIORef False
+  weAreDone <- newTVarIO False
 
   let acceptorConfig = mkAcceptorConfig endpoint weAreDone GetAllMetrics
       forwarderConfig = mkForwarderConfig endpoint
@@ -44,7 +45,7 @@ getAllMetrics endpoint = do
 
   threadDelay 2000000
 
-  atomicModifyIORef' weAreDone (const (True, ()))
+  atomically $ modifyTVar' weAreDone (const True)
 
   threadDelay 1000000
 

--- a/test/Test/GetMetrics.hs
+++ b/test/Test/GetMetrics.hs
@@ -6,8 +6,9 @@ module Test.GetMetrics
 import Test.Hspec
 
 import           Control.Concurrent (forkIO, threadDelay)
+import           Control.Concurrent.STM (atomically)
+import           Control.Concurrent.STM.TVar (modifyTVar', newTVarIO)
 import qualified Data.HashMap.Strict as HM
-import           Data.IORef (atomicModifyIORef', newIORef)
 import qualified Data.List.NonEmpty as NE
 import qualified System.Metrics as EKG
 import qualified System.Metrics.Gauge as G
@@ -29,7 +30,7 @@ getMetrics :: HowToConnect -> IO ()
 getMetrics endpoint = do
   forwarderStore <- EKG.newStore
   acceptorStore  <- EKG.newStore
-  weAreDone <- newIORef False
+  weAreDone <- newTVarIO False
 
   let acceptorConfig = mkAcceptorConfig endpoint weAreDone $
         GetMetrics $ NE.fromList ["test2.gauge.1", "test2.label.2"]
@@ -47,7 +48,7 @@ getMetrics endpoint = do
 
   threadDelay 2000000
 
-  atomicModifyIORef' weAreDone (const (True, ()))
+  atomically $ modifyTVar' weAreDone (const True)
 
   threadDelay 1000000
 

--- a/test/Test/MkConfig.hs
+++ b/test/Test/MkConfig.hs
@@ -3,8 +3,8 @@ module Test.MkConfig
   , mkForwarderConfig
   ) where
 
+import           Control.Concurrent.STM.TVar (TVar)
 import           Control.Tracer (nullTracer)
-import           Data.IORef (IORef)
 import           Data.Time.Clock (secondsToNominalDiffTime)
 
 import           System.Metrics.Configuration (AcceptorConfiguration (..),
@@ -14,7 +14,7 @@ import           System.Metrics.ReqResp (Request (..))
 
 mkAcceptorConfig
   :: HowToConnect
-  -> IORef Bool
+  -> TVar Bool
   -> Request
   -> AcceptorConfiguration
 mkAcceptorConfig endpoint weAreDone request =
@@ -23,9 +23,7 @@ mkAcceptorConfig endpoint weAreDone request =
     , forwarderEndpoint = endpoint
     , requestFrequency  = secondsToNominalDiffTime 1
     , whatToRequest     = request
-    , actionOnResponse  = \_ -> return ()
     , shouldWeStop      = weAreDone
-    , actionOnDone      = putStrLn "Acceptor: we are done!"
     }
 
 mkForwarderConfig


### PR DESCRIPTION
There is a breaking change with the update (`Ouroboros.Network.Codec` was moved to `Network.TypedProtocol.Codec.CBOR`) and `cardano-node` would require such an update from this package sooner or later.