### PR TITLE
Dummy version of the peer

### DIFF
--- a/src/System/Metrics/Store/Forwarder.hs
+++ b/src/System/Metrics/Store/Forwarder.hs
@@ -3,6 +3,7 @@
 
 module System.Metrics.Store.Forwarder
   ( mkResponse
+  , mkResponseDummy
   ) where
 
 import qualified Data.HashMap.Strict as HM
@@ -61,3 +62,11 @@ filterMetricsWeNeed mNames (mName, ekgValue) =
  where
   onlyIfNeeded value =
     if mName `elem` mNames then Just (mName, value) else Nothing
+
+mkResponseDummy
+  :: Forwarder.EKGForwarder Request Response IO ()
+mkResponseDummy =
+  Forwarder.EKGForwarder
+    { Forwarder.recvMsgReq  = const $ return (ResponseMetrics [], mkResponseDummy)
+    , Forwarder.recvMsgDone = return ()
+    }


### PR DESCRIPTION
Dummy version of the peer was added, to support optional `EKG.Store` on the forwarder's side.