### PR TITLE
Bump version to 0.2.0

### DIFF
--- a/ekg-forward.cabal
+++ b/ekg-forward.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                ekg-forward
-version:             0.1.0
+version:             0.2.0
 synopsis:            See README for more info
 description:         See README for more info
 homepage:            https://github.com/input-output-hk/ekg-forward


### PR DESCRIPTION
We're moving towards using [CHaP](https://github.com/input-output-hk/cardano-haskell-packages) for our Haskell packages. We're trying to bootstrap the process with the node. We set up the initial state with the versions and content of the packages used by the node at the Vasil release. Just recently, you bumped the version of `ekg-forward` in the node. For this to work in CHaP, we need to add a new version of `ekg-forward` corresponding to the one you just gave to the node.

We'll handle "releasing" it (and we'll talk more about how this goes in future), but for now is it okay to bump the version to 0.2.0?