### PR TITLE
Fix index-state syntax

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -13,10 +13,11 @@ repository cardano-haskell-packages
 
 -- See ouroboros-network/CONTRIBUTING for some Nix commands you will need 
 -- to run if you update either of these.
--- Bump this if you need newer packages from Hackage
-index-state: 2022-10-31T00:00:00Z
--- Bump this if you need newer packages from CHaP
-index-state: cardano-haskell-packages 2022-11-11T00:00:00Z
+index-state:
+  -- Bump this if you need newer packages from Hackage
+  , hackage.haskell.org 2022-10-31T00:00:00Z
+  -- Bump this if you need newer packages from CHaP
+  , cardano-haskell-packages 2022-11-11T00:00:00Z
 
 packages: ./.
 


### PR DESCRIPTION
The second index-state stanza completely ovverides the first, resetting hackage index state to HEAD. See haskell/cabal#8568