### PR TITLE
Use iog-contra-tracer instead of contra-tracer

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -24,6 +24,10 @@ index-state:
 
 packages: ./.
 
+constraints:
+  -- The API for this has changed so for now keep the old version.
+  ouroboro-network-framework < 0.6
+
 test-show-details: direct
 
 tests: True


### PR DESCRIPTION
There are two incompatible versions of the later, one on Hackage and one in CHaP.