### PR TITLE
Added bound needed for cardano-node build plan

### DIFF
--- a/ekg-forward.cabal
+++ b/ekg-forward.cabal
@@ -65,7 +65,7 @@ library
                        , io-classes >= 0.3
                        , network
                        , ouroboros-network-api
-                       , ouroboros-network-framework ^>= 0.7
+                       , ouroboros-network-framework ^>= 0.6 || ^>= 0.7
                        , serialise
                        , stm
                        , text


### PR DESCRIPTION
While updating CHaP I realised I removed a needed bound so this PR is to sync the `ekg-forward.cabal` file with ChaP's