### PR TITLE
ekg-forward 0.9 - Saving bandwidth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.9 - Mar 2025
+
+* New `Deltify` data type that selects only the delta/changes of metrics, keeping a reference to the previously transmitted sample in a back buffer.
+* Saving bandwidth: New request constructor `GetUpdatedMetrics` which asks for changed metrics only - with the initial back buffer being empty.
+* Saving bandwidth: New boolean field `useDummyForwarder` in `ForwarderConfiguration` to forcibly use a dummy forwarder, i.e. when the consumer is certain it wont require metrics at all.
+* New test case for `GetUpdatedMetrics`.
+* Updated to `ouroboros-network-framework-0.17`.
+
 ## 0.8.1
 
 * Updated to `ouroboros-network-framework-0.16`.

--- a/demo/forwarder.hs
+++ b/demo/forwarder.hs
@@ -28,6 +28,7 @@ main = do
           , acceptorEndpoint   = howToConnect
           , reConnectFrequency = secondsToNominalDiffTime (read freq :: Pico)
           , actionOnRequest    = \_ -> return ()
+          , useDummyForwarder  = False
           }
 
   -- Create an empty EKG store and register predefined GC metrics in it.

--- a/ekg-forward.cabal
+++ b/ekg-forward.cabal
@@ -1,13 +1,13 @@
 cabal-version:       2.4
 name:                ekg-forward
-version:             0.8.2
+version:             0.9
 synopsis:            See README for more info
 description:         See README for more info
 homepage:            https://github.com/input-output-hk/ekg-forward
 bug-reports:         https://github.com/input-output-hk/ekg-forward/issues
 license:             Apache-2.0
 license-file:        LICENSE
-copyright:           2021-2023 Input Output Global Inc (IOG), 2023-2024 Intersect.
+copyright:           2021-2023 Input Output Global Inc (IOG), 2023-2025 Intersect.
 author:              IOHK
 maintainer:          operations@iohk.io
 category:            System, Network
@@ -56,6 +56,8 @@ library
                        System.Metrics.Protocol.Codec
                        System.Metrics.Protocol.Acceptor
                        System.Metrics.Protocol.Forwarder
+
+  other-modules:       System.Metrics.Store.Deltify
 
   build-depends:         async
                        , bytestring
@@ -116,6 +118,7 @@ test-suite ekg-forward-test
   main-is:             Spec.hs
   other-modules:       Test.GetAllMetrics
                        Test.GetMetrics
+                       Test.GetUpdatedMetrics
                        Test.MkConfig
   build-depends:         base
                        , contra-tracer

--- a/src/System/Metrics/Configuration.hs
+++ b/src/System/Metrics/Configuration.hs
@@ -55,4 +55,6 @@ data ForwarderConfiguration = ForwarderConfiguration
     -- | Additional action that will be performed every time the forwarder will
     -- receive the request from the acceptor.
   , actionOnRequest    :: !(Request -> IO ())
+    -- | Forcibly use a dummy forwarder for metrics, i.e. when the consumer is certain they won't be needed
+  , useDummyForwarder  :: !Bool
   }

--- a/src/System/Metrics/Protocol/Codec.hs
+++ b/src/System/Metrics/Protocol/Codec.hs
@@ -4,7 +4,6 @@
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 
 module System.Metrics.Protocol.Codec (
   codecEKGForward

--- a/src/System/Metrics/Protocol/Type.hs
+++ b/src/System/Metrics/Protocol/Type.hs
@@ -1,12 +1,10 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE EmptyCase #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE StandaloneKindSignatures #-}
 {-# LANGUAGE TypeFamilies #-}
 
 -- | The type of the EKG forwarding/accepting protocol.

--- a/src/System/Metrics/ReqResp.hs
+++ b/src/System/Metrics/ReqResp.hs
@@ -33,6 +33,7 @@ instance Serialise MetricValue
 data Request
   = GetAllMetrics                      -- ^ Get all metrics from the forwarder's local store.
   | GetMetrics !(NonEmpty MetricName)  -- ^ Get specific metrics only.
+  | GetUpdatedMetrics                  -- ^ Get all metrics from the forwarder's local store that have changed since the last request.
   deriving (Eq, Generic, Show)
 
 -- | The response with the metrics.

--- a/src/System/Metrics/Store/Deltify.hs
+++ b/src/System/Metrics/Store/Deltify.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE RecordWildCards #-}
+
+module System.Metrics.Store.Deltify
+       ( Deltify(..)
+       , mkDeltify
+       ) where
+
+import           Control.Concurrent.Class.MonadSTM.TVar
+import           Control.Monad.Class.MonadSTM
+import qualified Data.HashMap.Strict                    as HM
+import           System.Metrics                         (Sample)
+
+
+data Deltify m = Deltify
+  { deltaPutAll   :: Sample -> m ()           -- ^ put an entire Sample into the backbuffer
+  , deltaDeltify  :: Sample -> m Sample       -- ^ return delta to current backbuffer, and update backbuffer
+  , deltaPutDelta :: Sample -> m ()           -- ^ apply delta to backbuffer
+  }
+
+newtype BackBuffer = BackBuffer Sample        -- ^ the backbuffer holds the latest sample that was base for a Response
+
+
+{-# SPECIALIZE mkDeltify :: IO (Deltify IO) #-}
+mkDeltify :: MonadSTM m => m (Deltify m)
+mkDeltify = do
+  backBuffer <- newTVarIO (BackBuffer HM.empty)
+
+  let
+    deltaPutAll     = atomically . writeTVar backBuffer . BackBuffer
+    deltaDeltify    = atomically . stateTVar backBuffer . getDelta
+    deltaPutDelta   = atomically . modifyTVar' backBuffer . putDelta
+  pure Deltify{..}
+  where
+    putDelta :: Sample -> BackBuffer -> BackBuffer
+    putDelta curr (BackBuffer prev) = BackBuffer (HM.union curr prev)
+
+    getDelta :: Sample -> BackBuffer -> (Sample, BackBuffer)
+    getDelta curr (BackBuffer prev) = (updateMetrics, BackBuffer curr)
+      where
+        updateMetrics = HM.differenceWith (\v' v -> if v' == v then Nothing else Just v') curr prev

--- a/src/System/Metrics/Store/Forwarder.hs
+++ b/src/System/Metrics/Store/Forwarder.hs
@@ -1,37 +1,50 @@
 {-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE ViewPatterns    #-}
 
 module System.Metrics.Store.Forwarder
   ( mkResponse
   , mkResponseDummy
   ) where
 
-import qualified Data.HashMap.Strict as HM
-import qualified Data.List.NonEmpty as NE
-import           Data.Maybe (mapMaybe)
-import qualified System.Metrics as EKG
+import qualified Data.HashMap.Strict               as HM
+import qualified Data.HashSet                      as HS
+import qualified Data.List.NonEmpty                as NE
+import           Data.Maybe                        (mapMaybe)
+import qualified System.Metrics                    as EKG
 
-import           System.Metrics.Configuration (ForwarderConfiguration (..))
-import           System.Metrics.ReqResp (MetricName, MetricValue (..),
-                                         Request (..), Response (..)) 
+import           System.Metrics.Configuration      (ForwarderConfiguration (..))
 import qualified System.Metrics.Protocol.Forwarder as Forwarder
+import           System.Metrics.ReqResp            (MetricName,
+                                                    MetricValue (..),
+                                                    Request (..), Response (..))
+import           System.Metrics.Store.Deltify
+
 
 mkResponse
   :: ForwarderConfiguration
+  -> Deltify IO
   -> EKG.Store
   -> Forwarder.EKGForwarder Request Response IO ()
-mkResponse ForwarderConfiguration{..} ekgStore =
+mkResponse ForwarderConfiguration{..} Deltify{..} ekgStore =
   Forwarder.EKGForwarder
     { Forwarder.recvMsgReq = \request -> do
         actionOnRequest request
-        allMetrics <- HM.toList <$> EKG.sampleAll ekgStore
+        sample <- EKG.sampleAll ekgStore
         case request of
-          GetAllMetrics -> do
-            let supportedMetrics = mapMaybe filterMetrics allMetrics
+          GetUpdatedMetrics -> do
+            sample' <- deltaDeltify sample
+            let supportedMetrics = mapMaybe filterMetrics $ HM.toList sample'
             return $ ResponseMetrics supportedMetrics
-          GetMetrics (NE.toList -> mNames) -> do
-            let metricsWeNeed = mapMaybe (filterMetricsWeNeed mNames) allMetrics
-            return $ ResponseMetrics metricsWeNeed
+          GetAllMetrics -> do
+            let supportedMetrics = mapMaybe filterMetrics $ HM.toList sample
+            deltaPutAll sample
+            return $ ResponseMetrics supportedMetrics
+          GetMetrics (HS.fromList . NE.toList -> mNames) -> do
+            let
+              sample' = filterSample mNames sample
+              supportedMetrics = mapMaybe filterMetrics $ HM.toList sample'
+            deltaPutDelta sample'
+            return $ ResponseMetrics supportedMetrics
     , Forwarder.recvMsgDone = return ()
     }
 
@@ -40,24 +53,16 @@ filterMetrics
   -> Maybe (MetricName, MetricValue)
 filterMetrics (mName, ekgValue) =
   case ekgValue of
-    EKG.Distribution _ -> Nothing  -- Distribution does not supported yet.
     EKG.Counter c      -> Just (mName, CounterValue c)
     EKG.Gauge g        -> Just (mName, GaugeValue g)
     EKG.Label l        -> Just (mName, LabelValue l)
-
-filterMetricsWeNeed
-  :: [MetricName]
-  -> (MetricName, EKG.Value)
-  -> Maybe (MetricName, MetricValue)
-filterMetricsWeNeed mNames (mName, ekgValue) =
-  case ekgValue of
     EKG.Distribution _ -> Nothing  -- Distribution does not supported yet.
-    EKG.Counter c      -> onlyIfNeeded $ CounterValue c
-    EKG.Gauge g        -> onlyIfNeeded $ GaugeValue g
-    EKG.Label l        -> onlyIfNeeded $ LabelValue l
- where
-  onlyIfNeeded value =
-    if mName `elem` mNames then Just (mName, value) else Nothing
+
+filterSample
+  :: HS.HashSet MetricName
+  -> EKG.Sample
+  -> EKG.Sample
+filterSample mNames = HM.filterWithKey (\k _ -> k `HS.member` mNames)
 
 mkResponseDummy
   :: Forwarder.EKGForwarder Request Response IO ()

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -2,6 +2,7 @@ import           Test.Hspec
 
 import           Test.GetAllMetrics
 import           Test.GetMetrics
+import           Test.GetUpdatedMetrics
 
 main :: IO ()
 main = hspec $ do
@@ -10,8 +11,12 @@ main = hspec $ do
       getAllMetricsViaPipe
     it "request of some metrics"
       getMetricsViaPipe
+    it "request of updated metrics"
+      getUpdatedMetricsViaPipe
   describe "EKG metrics forwarding, via remote socket" $ do
     it "request of all metrics"
       getAllMetricsViaSocket
     it "request of some metrics"
       getMetricsViaSocket
+    it "request of updated metrics"
+      getUpdatedMetricsViaSocket

--- a/test/Test/GetUpdatedMetrics.hs
+++ b/test/Test/GetUpdatedMetrics.hs
@@ -1,0 +1,61 @@
+module Test.GetUpdatedMetrics
+  ( getUpdatedMetricsViaPipe
+  , getUpdatedMetricsViaSocket
+  ) where
+
+import Test.Hspec
+
+import           Control.Concurrent (forkIO, threadDelay)
+import           Control.Concurrent.STM (atomically)
+import           Control.Concurrent.STM.TVar (modifyTVar', newTVarIO)
+import qualified System.Metrics as EKG
+import qualified System.Metrics.Gauge as G
+import qualified System.Metrics.Label as L
+import qualified System.Metrics.Counter as C
+
+import           System.Metrics.Acceptor (runEKGAcceptor)
+import           System.Metrics.Forwarder (runEKGForwarder)
+import           System.Metrics.Configuration (HowToConnect (..))
+import           System.Metrics.ReqResp (Request (..))
+
+import           Test.MkConfig (mkAcceptorConfig, mkForwarderConfig)
+
+getUpdatedMetricsViaPipe, getUpdatedMetricsViaSocket :: IO ()
+getUpdatedMetricsViaPipe   = getUpdatedMetrics $ LocalPipe "/tmp/ekg-forward-test-3.sock"
+getUpdatedMetricsViaSocket = getUpdatedMetrics $ RemoteSocket "127.0.0.1" 3030
+
+getUpdatedMetrics :: HowToConnect -> IO ()
+getUpdatedMetrics endpoint = do
+  forwarderStore <- EKG.newStore
+  acceptorStore  <- EKG.newStore
+  weAreDone <- newTVarIO False
+
+  let acceptorConfig = mkAcceptorConfig endpoint weAreDone GetUpdatedMetrics
+      forwarderConfig = mkForwarderConfig endpoint
+
+  _acceptorThr <- forkIO $ runEKGAcceptor acceptorConfig acceptorStore
+
+  EKG.createGauge         "test1.gauge.1" forwarderStore >>= flip G.set 123
+  g2 <- EKG.createGauge   "test1.gauge.2" forwarderStore
+  G.set g2 456      
+  EKG.createLabel         "test1.label.1" forwarderStore >>= flip L.set "TestLabel_1"
+  l2 <- EKG.createLabel   "test1.label.2" forwarderStore 
+  L.set l2 "TestLabel_2"
+  EKG.createCounter       "test1.cntr.1"  forwarderStore >>= flip C.add 10
+      
+  _forwarderThr <- forkIO $ runEKGForwarder forwarderConfig forwarderStore
+
+  threadDelay 1500000
+  G.set g2 789
+  L.set l2 "TestLabel_3.1415"
+  EKG.createCounter       "test1.cntr.2"  forwarderStore >>= flip C.add 42
+  threadDelay 1500000
+
+  atomically $ modifyTVar' weAreDone (const True)
+
+  threadDelay 1000000
+
+  forwarderMetrics <- EKG.sampleAll forwarderStore
+  acceptorMetrics  <- EKG.sampleAll acceptorStore
+
+  acceptorMetrics `shouldBe` forwarderMetrics

--- a/test/Test/MkConfig.hs
+++ b/test/Test/MkConfig.hs
@@ -35,4 +35,5 @@ mkForwarderConfig endpoint =
     , acceptorEndpoint   = endpoint
     , reConnectFrequency = secondsToNominalDiffTime 1
     , actionOnRequest    = \_ -> return ()
+    , useDummyForwarder  = False
     }


### PR DESCRIPTION
This PR aims at saving bandwidth when transmitting metrics from an emitting process to a consuming service.

* A new, internal `Deltify` data type selects only the delta/changes of metrics, keeping a reference to the previously transmitted sample in a back buffer.
* New request constructor `GetUpdatedMetrics` which asks changed metrics only - with the initial back buffer being empty.
* New boolean field `useDummyForwarder` in `ForwarderConfiguration` to forcibly use a dummy forwarder, i.e. when the consumer is certain it wont require metrics at all.

The test suite is updated with a new case for `GetUpdatedMetrics`.

The changes are forward-compatible for existing code, i.e. it will run unchanged with `ekg-forward-0.9` - with one exception: it needs to set `useDummyForwarder` to `False` whenever defining a `ForwarderConfiguration`.