### PR TITLE
coot/ouroboros network framework 0.17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
         ghc: [ "8.10.7", "9.2.7", "9.6.1" ]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/master'
 
-    - uses: haskell/actions/setup@v1
+    - uses: haskell-actions/setup@v2
       name: Setup Haskell
       with:
         ghc-version: ${{ matrix.ghc }}
@@ -28,7 +28,7 @@ jobs:
       run: |
         cabal freeze
 
-    - uses: actions/cache@v2
+    - uses: actions/cache@v4
       name: Cache ~/.cabal/store
       with:
         path: |

--- a/cabal.project
+++ b/cabal.project
@@ -17,7 +17,7 @@ repository cardano-haskell-packages
 
 index-state:
   , hackage.haskell.org 2025-02-04T00:00:00Z
-  , cardano-haskell-packages 2025-02-04T06:43:15Z
+  , cardano-haskell-packages 2025-02-26T16:38:32Z
 
 packages: ./.
 

--- a/cabal.project
+++ b/cabal.project
@@ -25,9 +25,3 @@ test-show-details: direct
 
 tests: True
 benchmarks: True
-
-if impl(ghc >= 9.6)
-  allow-newer:
-    , *:base
-    , ekg-core:*
-    , protolude:*

--- a/ekg-forward.cabal
+++ b/ekg-forward.cabal
@@ -66,7 +66,7 @@ library
                        , network
                        , network-mux
                        , ouroboros-network-api
-                       , ouroboros-network-framework ^>= 0.16
+                       , ouroboros-network-framework ^>= 0.17
                        , singletons ^>= 3.0
                        , serialise
                        , stm

--- a/ekg-forward.cabal
+++ b/ekg-forward.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                ekg-forward
-version:             0.8.1
+version:             0.8.2
 synopsis:            See README for more info
 description:         See README for more info
 homepage:            https://github.com/input-output-hk/ekg-forward

--- a/src/System/Metrics/Network/Acceptor.hs
+++ b/src/System/Metrics/Network/Acceptor.hs
@@ -123,6 +123,7 @@ acceptorApp config mkStores peerErrorHandler =
   OuroborosApplication [
     MiniProtocol
       { miniProtocolNum    = MiniProtocolNum 2
+      , miniProtocolStart  = Mux.StartEagerly
       , miniProtocolLimits = MiniProtocolLimits { maximumIngressQueue = maxBound }
       , miniProtocolRun    = acceptEKGMetricsResp config mkStores peerErrorHandler
       }

--- a/src/System/Metrics/Network/Forwarder.hs
+++ b/src/System/Metrics/Network/Forwarder.hs
@@ -131,6 +131,7 @@ forwarderApp config ekgStore =
   OuroborosApplication
     [ MiniProtocol
         { miniProtocolNum    = MiniProtocolNum 2
+        , miniProtocolStart  = Mux.StartEagerly
         , miniProtocolLimits = MiniProtocolLimits { maximumIngressQueue = maxBound }
         , miniProtocolRun    = forwardEKGMetrics config ekgStore
         }


### PR DESCRIPTION
- **ouroboros-network-0.17**
- **cabal.project: drop not needed configuration**
- **Bump version to `0.8.2`**
