### PR TITLE
Prepare ekg-forward-1.0 release

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -17,7 +17,7 @@ repository cardano-haskell-packages
 
 index-state:
   , hackage.haskell.org 2025-07-22T09:13:54Z
-  , cardano-haskell-packages 2025-07-28T14:33:19Z
+  , cardano-haskell-packages 2025-08-27T16:03:36Z
 
 packages: ./.
 

--- a/ekg-forward.cabal
+++ b/ekg-forward.cabal
@@ -1,6 +1,6 @@
 cabal-version:       3.0
 name:                ekg-forward
-version:             0.9
+version:             1.0
 synopsis:            See README for more info
 description:         See README for more info
 homepage:            https://github.com/input-output-hk/ekg-forward
@@ -27,13 +27,10 @@ common common-options
                        -Widentities
                        -Wincomplete-uni-patterns
                        -Wincomplete-record-updates
-  if impl(ghc >= 8.0)
-    ghc-options:       -Wredundant-constraints
-  if impl(ghc >= 8.2)
-    ghc-options:       -fhide-source-paths
-  if impl(ghc >= 8.4)
-    ghc-options:       -Wmissing-export-lists
+                       -Wredundant-constraints
+                       -Wmissing-export-lists
                        -Wpartial-fields
+                       -fhide-source-paths
 
   default-language:    Haskell2010
 

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1755197699,
-        "narHash": "sha256-Qpmv1zYOfOzYZfU3sB3bsv/sGtI1c6MGTFiyhnYmmRA=",
+        "lastModified": 1758547838,
+        "narHash": "sha256-QvqwgT4yN+52SWxQWQ3cS5V64C1rQrQKaLCYRZH7bC4=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "982aa1c76e28e26e592e26e8fd8b73eea87dbdc2",
+        "rev": "6174af87848e7b5e652bb19035f658e10f094299",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -44,7 +44,7 @@
         cabalProject = nixpkgs.haskell-nix.cabalProject' {
           src = ./.;
           name = "ekg-forward";
-          compiler-nix-name = "ghc8107";
+          compiler-nix-name = "ghc966";
 
           # CHaP input map, so we can find CHaP packages (needs to be more
           # recent than the index-state we set!). Can be updated with


### PR DESCRIPTION
This PR prepares the `ekg-forward-1.0` release.

* `.cabal` file bumps package version and drops GHC8 compatibility
* The CHaP bump allows for `ouroboros-network-framework-0.19.1`
* The nix compiler version is switched to GHC 9.6.6
