### PR TITLE
Generalise metric acceptance mini-protocol to arbitrary stores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.2 - Mar 2026
+
+* Generalised metrics acceptor to work with an arbitrary store.
+
 ## 1.1 - Mar 2026
 
 * Updated to `typed-protocols-1.2`.

--- a/ekg-forward.cabal
+++ b/ekg-forward.cabal
@@ -1,6 +1,6 @@
 cabal-version:       3.0
 name:                ekg-forward
-version:             1.1
+version:             1.2
 synopsis:            See README for more info
 description:         See README for more info
 homepage:            https://github.com/input-output-hk/ekg-forward

--- a/src/System/Metrics/Acceptor.hs
+++ b/src/System/Metrics/Acceptor.hs
@@ -13,7 +13,7 @@ import           Control.Monad (void)
 import qualified System.Metrics as EKG
 
 import           System.Metrics.Network.Acceptor (listenToForwarder)
-import           System.Metrics.Store.Acceptor (emptyMetricsLocalStore)
+import           System.Metrics.Store.Acceptor (emptyMetricsLocalStore, storeMetrics)
 import           System.Metrics.Configuration (AcceptorConfiguration (..))
 
 runEKGAcceptor
@@ -21,12 +21,14 @@ runEKGAcceptor
   -> EKG.Store              -- ^ The store all received metrics will be stored in.
   -> IO ()
 runEKGAcceptor config ekgStore =
-  try (void $ listenToForwarder config mkStores peerErrorHandler) >>= \case
+  try (void $ listenToForwarder config mkStores insertStores peerErrorHandler) >>= \case
     Left (_e :: SomeException) -> runEKGAcceptor config ekgStore
     Right _ -> return ()
  where
   mkStores _ = do
     metricsStore <- newTVarIO emptyMetricsLocalStore
     return (ekgStore, metricsStore)
+
+  insertStores _ (a, b) resp = storeMetrics resp a b
 
   peerErrorHandler _ = return ()

--- a/src/System/Metrics/Network/Acceptor.hs
+++ b/src/System/Metrics/Network/Acceptor.hs
@@ -13,7 +13,7 @@ import qualified Codec.Serialise as CBOR
 import           Control.Exception (finally)
 import           Control.Concurrent (threadDelay)
 import           Control.Concurrent.Async (wait)
-import           Control.Concurrent.STM.TVar (TVar, readTVarIO)
+import           Control.Concurrent.STM.TVar (readTVarIO)
 import           Control.Tracer (nullTracer)
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Text as T
@@ -48,30 +48,28 @@ import           Ouroboros.Network.Protocol.Handshake.Unversioned (UnversionedPr
                                                                    unversionedProtocolDataCodec)
 import           Ouroboros.Network.Protocol.Limits (ProtocolTimeLimits)
 
-import qualified System.Metrics as EKG
-
 import qualified System.Metrics.Protocol.Acceptor as Acceptor
 import qualified System.Metrics.Protocol.Codec as Acceptor
-import           System.Metrics.Store.Acceptor (MetricsLocalStore (..), storeMetrics)
 import           System.Metrics.ReqResp (Request (..), Response (..))
 import           System.Metrics.Configuration (AcceptorConfiguration (..), HowToConnect (..))
 
 listenToForwarder
   :: AcceptorConfiguration
-  -> (ResponderContext (Either LocalAddress Socket.SockAddr) -> IO (EKG.Store, TVar MetricsLocalStore))
+  -> (ResponderContext (Either LocalAddress Socket.SockAddr) -> IO store)
+  -> (ResponderContext (Either LocalAddress Socket.SockAddr) -> store -> Response -> IO ())
   -> (ResponderContext (Either LocalAddress Socket.SockAddr) -> IO ())
   -> IO Void
-listenToForwarder config mkStores peerErrorHandler = withIOManager $ \iocp -> do
+listenToForwarder config mkStore insertStore peerErrorHandler = withIOManager $ \iocp -> do
   case forwarderEndpoint config of
     LocalPipe localPipe -> do
-      let app = acceptorApp config (mkStores . fmap Left) (peerErrorHandler . fmap Left)
+      let app = acceptorApp config (mkStore . fmap Left) (insertStore . fmap Left) (peerErrorHandler . fmap Left)
           snocket = localSnocket iocp
           address = localAddressFromPath localPipe
           configureSocket = mempty
       doListenToForwarder snocket makeLocalBearer configureSocket address noTimeLimitsHandshake app
     RemoteSocket host port -> do
       listenAddress:_ <- Socket.getAddrInfo Nothing (Just $ T.unpack host) (Just $ show port)
-      let app = acceptorApp config (mkStores . fmap Right) (peerErrorHandler . fmap Right)
+      let app = acceptorApp config (mkStore . fmap Right) (insertStore . fmap Right) (peerErrorHandler . fmap Right)
           snocket = socketSnocket iocp
           address = Socket.addrAddress listenAddress
           configureSocket fd _addr =
@@ -114,71 +112,76 @@ doListenToForwarder snocket makeBearer configureSocket address timeLimits app = 
 
 acceptorApp
   :: AcceptorConfiguration
-  -> (ResponderContext addr -> IO (EKG.Store, TVar MetricsLocalStore))
+  -> (ResponderContext addr -> IO store)
+  -> (ResponderContext addr -> store -> Response -> IO ())
   -> (ResponderContext addr -> IO ())
   -> OuroborosApplication 'Mux.ResponderMode
                           (MinimalInitiatorContext addr)
                           (ResponderContext addr)
                           LBS.ByteString IO Void ()
-acceptorApp config mkStores peerErrorHandler =
+acceptorApp config mkStore insertStore peerErrorHandler =
   OuroborosApplication [
     MiniProtocol
       { miniProtocolNum    = MiniProtocolNum 2
       , miniProtocolStart  = Mux.StartEagerly
       , miniProtocolLimits = MiniProtocolLimits { maximumIngressQueue = maxBound }
-      , miniProtocolRun    = acceptEKGMetricsResp config mkStores peerErrorHandler
+      , miniProtocolRun    = acceptEKGMetricsResp config mkStore insertStore peerErrorHandler
       }
   ]
 
+-- COMMENT: Remove 'EKG' from the name?
 acceptEKGMetricsResp
   :: AcceptorConfiguration
-  -> (responderCtx -> IO (EKG.Store, TVar MetricsLocalStore))
+  -> (responderCtx -> IO store)
+  -> (responderCtx -> store -> Response -> IO ())
   -> (responderCtx -> IO ())
   -> RunMiniProtocol 'Mux.ResponderMode initiatorCtx responderCtx LBS.ByteString IO Void ()
-acceptEKGMetricsResp config mkStores peerErrorHandler =
-  ResponderProtocolOnly $ runPeerWithStores config mkStores peerErrorHandler
+acceptEKGMetricsResp config mkStore insertStore peerErrorHandler =
+  ResponderProtocolOnly $ runPeerWithStores config mkStore insertStore peerErrorHandler
 
+-- COMMENT: Remove 'EKG' from the name?
 acceptEKGMetricsInit
   :: AcceptorConfiguration
-  -> (initiatorCtx -> IO (EKG.Store, TVar MetricsLocalStore))
+  -> (initiatorCtx -> IO store)
+  -> (initiatorCtx -> store -> Response -> IO ())
   -> (initiatorCtx -> IO ())
   -> RunMiniProtocol 'Mux.InitiatorMode initiatorCtx responderCtx LBS.ByteString IO () Void
-acceptEKGMetricsInit config mkStores peerErrorHandler =
-  InitiatorProtocolOnly $ runPeerWithStores config mkStores peerErrorHandler
+acceptEKGMetricsInit config mkStore insertStore peerErrorHandler =
+  InitiatorProtocolOnly $ runPeerWithStores config mkStore insertStore peerErrorHandler
 
 runPeerWithStores
   :: AcceptorConfiguration
-  -> (ctx -> IO (EKG.Store, TVar MetricsLocalStore))
+  -> (ctx -> IO store)
+  -> (ctx -> store -> Response -> IO ())
   -> (ctx -> IO ())
   -> MiniProtocolCb ctx LBS.ByteString IO ()
-runPeerWithStores config mkStores peerErrorHandler =
+runPeerWithStores config mkStore insertStore peerErrorHandler =
   MiniProtocolCb $ \ctx channel -> do
-    (ekgStore, metricsStore) <- mkStores ctx
+    st <- mkStore ctx
     runPeer
       (acceptorTracer config)
       (Acceptor.codecEKGForward CBOR.encode CBOR.decode
                                 CBOR.encode CBOR.decode)
       channel
-      (Acceptor.ekgAcceptorPeer $ acceptorActions True config ekgStore metricsStore)
+      (Acceptor.ekgAcceptorPeer $ acceptorActions True config (insertStore ctx st))
     `finally` peerErrorHandler ctx
 
 acceptorActions
   :: Bool
   -> AcceptorConfiguration
-  -> EKG.Store
-  -> TVar MetricsLocalStore
+  -> (Response -> IO ())
   -> Acceptor.EKGAcceptor Request Response IO ()
-acceptorActions True config@AcceptorConfiguration{..} ekgStore metricsStore =
+acceptorActions True config@AcceptorConfiguration{..} insertStore =
   Acceptor.SendMsgReq whatToRequest $ \response -> do
-    storeMetrics response ekgStore metricsStore
+    insertStore response
     threadDelay $ toMicroSecs requestFrequency
     weAreDone <- readTVarIO shouldWeStop
     if weAreDone
-      then return $ acceptorActions False config ekgStore metricsStore
-      else return $ acceptorActions True  config ekgStore metricsStore
+      then return $ acceptorActions False config insertStore
+      else return $ acceptorActions True  config insertStore
  where
   toMicroSecs :: NominalDiffTime -> Int
   toMicroSecs dt = fromEnum dt `div` 1000000
 
-acceptorActions False _ _ _ =
+acceptorActions False _ _ =
   Acceptor.SendMsgDone $ return ()

--- a/src/System/Metrics/Network/Acceptor.hs
+++ b/src/System/Metrics/Network/Acceptor.hs
@@ -6,6 +6,8 @@ module System.Metrics.Network.Acceptor
   -- | Export this function for Mux purpose.
   , acceptEKGMetricsInit
   , acceptEKGMetricsResp
+  , acceptMetricsInit
+  , acceptMetricsResp
   ) where
 
 import           Codec.CBOR.Term (Term)
@@ -13,7 +15,7 @@ import qualified Codec.Serialise as CBOR
 import           Control.Exception (finally)
 import           Control.Concurrent (threadDelay)
 import           Control.Concurrent.Async (wait)
-import           Control.Concurrent.STM.TVar (readTVarIO)
+import           Control.Concurrent.STM.TVar (TVar, readTVarIO)
 import           Control.Tracer (nullTracer)
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Text as T
@@ -52,6 +54,8 @@ import qualified System.Metrics.Protocol.Acceptor as Acceptor
 import qualified System.Metrics.Protocol.Codec as Acceptor
 import           System.Metrics.ReqResp (Request (..), Response (..))
 import           System.Metrics.Configuration (AcceptorConfiguration (..), HowToConnect (..))
+import qualified System.Metrics as EKG
+import System.Metrics.Store.Acceptor (MetricsLocalStore, storeMetrics)
 
 listenToForwarder
   :: AcceptorConfiguration
@@ -125,29 +129,47 @@ acceptorApp config mkStore insertStore peerErrorHandler =
       { miniProtocolNum    = MiniProtocolNum 2
       , miniProtocolStart  = Mux.StartEagerly
       , miniProtocolLimits = MiniProtocolLimits { maximumIngressQueue = maxBound }
-      , miniProtocolRun    = acceptEKGMetricsResp config mkStore insertStore peerErrorHandler
+      , miniProtocolRun    = acceptMetricsResp config mkStore insertStore peerErrorHandler
       }
   ]
 
--- COMMENT: Remove 'EKG' from the name?
-acceptEKGMetricsResp
+{-# INLINE acceptMetricsResp #-}
+acceptMetricsResp
   :: AcceptorConfiguration
   -> (responderCtx -> IO store)
   -> (responderCtx -> store -> Response -> IO ())
   -> (responderCtx -> IO ())
   -> RunMiniProtocol 'Mux.ResponderMode initiatorCtx responderCtx LBS.ByteString IO Void ()
-acceptEKGMetricsResp config mkStore insertStore peerErrorHandler =
+acceptMetricsResp config mkStore insertStore peerErrorHandler =
   ResponderProtocolOnly $ runPeerWithStores config mkStore insertStore peerErrorHandler
 
--- COMMENT: Remove 'EKG' from the name?
-acceptEKGMetricsInit
+{-# INLINE acceptMetricsInit #-}
+acceptMetricsInit
   :: AcceptorConfiguration
   -> (initiatorCtx -> IO store)
   -> (initiatorCtx -> store -> Response -> IO ())
   -> (initiatorCtx -> IO ())
   -> RunMiniProtocol 'Mux.InitiatorMode initiatorCtx responderCtx LBS.ByteString IO () Void
-acceptEKGMetricsInit config mkStore insertStore peerErrorHandler =
+acceptMetricsInit config mkStore insertStore peerErrorHandler =
   InitiatorProtocolOnly $ runPeerWithStores config mkStore insertStore peerErrorHandler
+
+acceptEKGMetricsResp
+  :: AcceptorConfiguration
+  -> (responderCtx -> IO (EKG.Store, TVar MetricsLocalStore))
+  -> (responderCtx -> IO ())
+  -> RunMiniProtocol 'Mux.ResponderMode initiatorCtx responderCtx LBS.ByteString IO Void ()
+acceptEKGMetricsResp config mkStore =
+  acceptMetricsResp config mkStore insertStore where
+    insertStore _ (a, b) resp = storeMetrics resp a b
+
+acceptEKGMetricsInit
+  :: AcceptorConfiguration
+  -> (initiatorCtx -> IO (EKG.Store, TVar MetricsLocalStore))
+  -> (initiatorCtx -> IO ())
+  -> RunMiniProtocol 'Mux.InitiatorMode initiatorCtx responderCtx LBS.ByteString IO () Void
+acceptEKGMetricsInit config mkStore =
+  acceptMetricsInit config mkStore insertStore where
+    insertStore _ (a, b) resp = storeMetrics resp a b
 
 runPeerWithStores
   :: AcceptorConfiguration


### PR DESCRIPTION
`cardano-tracer` is one of the users of the mini-protocol. The original solution keeps two kinds of store updated (EKG and "local"). We'd like to support arbitrary stores (it's enough to support another custom store but for obvious reasons that's not a scalable solution).